### PR TITLE
Improve CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
       - run:
           name: Deploying to GitHub Pages
           command: |
-            git config --global user.email "jceipek@users.noreply.github.com"
-            git config --global user.name "Julian Ceipek"
-            cd website && yarn install && GIT_USER=jceipek USE_SSH=true CUSTOM_COMMIT_MESSAGE="[skip ci] Automated Deploy via CircleCI" yarn run publish-gh-pages
+            git config --global user.email "ops@darklang.com"
+            git config --global user.name "Dark Ops"
+            cd website && yarn install USE_SSH=true CUSTOM_COMMIT_MESSAGE="[skip ci] Automated Deploy of $CIRCLE_SHA1 via CircleCI" yarn run publish-gh-pages
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -181,4 +181,4 @@ $ cd website
 $ GIT_USER=<YOUR USERNAME> CURRENT_BRANCH=master yarn publish-gh-pages
 ```
 
-If you're using ssh instead of https, also add the prefix `USE_SSH=true`.
+If you're using ssh instead of https, replace `GIT_USER=<YOUR USERNAME>` with `USE_SSH=true`.


### PR DESCRIPTION
- Use `master` instead of `src`
- Change deployer to `ops@darklang.com` and `Dark Ops`
- Add SHA1 to deploys

Note that after this PR is merged, I will delete the `src` branch.