### PR TITLE
Fix language doc

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -89,7 +89,7 @@ including iterating across them, random access, push/pop, etc.
 
 ```elm
 let x = [8]
-let y = x ++ [6]
+let y = List::append x [6]
 y
 ```
 

--- a/docs/structured-editing.md
+++ b/docs/structured-editing.md
@@ -11,7 +11,7 @@ When writing code in Dark, you are building up expressions, relying heavily on a
 
 ## Blanks
 
-A blank expressions acts as a placeholder where you can type to create a different expression. The value of a blank expression is `Incomplete`, because it needs to be completed in order to be useful.
+A blank expression acts as a placeholder where you can type to create a different expression. The value of a blank expression is `Incomplete`, because it needs to be completed in order to be useful.
 
 ![Blank Example](assets/structuredediting/blank_example.png)
 


### PR DESCRIPTION
Minor copy edits:

1) Switched to list::append instead of ++ on the language example, had confused a user who was getting type errors.
2) Fixed a structured editor typo that @jceipek had flagged, getting to the more substantive notes after. 