### PR TITLE
Pass on early docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           cd website
           yarn install
           yarn lint
+          yarn check-format
           yarn docusaurus-build
 
   deploy-website:

--- a/docs/first-api-endpoint.md
+++ b/docs/first-api-endpoint.md
@@ -9,28 +9,28 @@ title: Your first API endpoint
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.10.26_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.10.26_AM.png)
 
-2. Specify that the verb is `GET` and the route is `/math`.
+2. Enter the HTTP verb as `GET` and  `/math` for the route.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.11.23_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.11.23_AM.png)
 
-3. You can now write any code in the blank &ndash; this is the return value of the handler. To start with, let's just return `4`.
+3. You can now write any code in the blank &ndash; this is the return value of the API endpoint that you've just created. To start with, let's just return `4`.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.12.02_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.12.02_AM.png)
 
-Click the hamburger in the upper right and select "open in new tab", to see your API endpoint running in production.
+4. Click the handler's menu (☰) in the upper right and select "open in new tab", to see your API endpoint running in production.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.12.43_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.12.43_AM.png)
 
-4. Go back to Dark to edit your code. Add `+ 5` to the end of the code and leave your cursor in line.
+5. Go back to Dark to edit your code. Add `+ 5` to the end of the code and leave your cursor in line.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.14.25_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.14.25_AM.png)
 
-- The `9` at the bottom shows you the return value for the handler.
+- The `9` below the handler shows you the return value for the handler.
 
 - The `5` on the left shows you the result of the expression where the cursor currently is (in this case, 5). This isn't very useful when it's an integer, but if it's a variable it will show you the result of the variable.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.16.06_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.16.06_AM.png)
 
-5. Mouse over the white dots on the left. Each dot is a "trace" of a single request to your handler.
+6. Mouse over the white dots on the left. Each dot is a "trace" of a single request to your handler.
 
 Congratulations! You've shipped your first Dark API endpoint.

--- a/docs/first-api-endpoint.md
+++ b/docs/first-api-endpoint.md
@@ -9,7 +9,7 @@ title: Your first API endpoint
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.10.26_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.10.26_AM.png)
 
-2. Enter the HTTP verb as `GET` and  `/math` for the route.
+2. Enter the HTTP verb as `GET` and `/math` for the route.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.11.23_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.11.23_AM.png)
 

--- a/docs/first-api-endpoint.md
+++ b/docs/first-api-endpoint.md
@@ -31,6 +31,8 @@ title: Your first API endpoint
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.16.06_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.16.06_AM.png)
 
-6. Mouse over the white dots on the left. Each dot is a "trace" of a single request to your handler.
+6. Mouse over the white dots on the left. Each dot is a "trace", representing a
+   single request to your handler. Traces are fundamental to coding in Dark,
+   and we'll come back to them later.
 
 Congratulations! You've shipped your first Dark API endpoint.

--- a/docs/first-datastore.md
+++ b/docs/first-datastore.md
@@ -3,33 +3,33 @@ id: first-datastore
 title: Your first Datastore
 ---
 
-We can use the trace of that HTTP request to build the endpoint. This is Trace Driven Development.
+In the last section, we made a HTTP request that created a 404. We'll use _the trace_ of that HTTP request to build an endpoint, a technique we call **Trace Driven Development**.
 
-1. Hit the + button in the 404 section of the side bar to create the HTTP endpoint. The verb (POST) and route (/test) will be set for you.
+1. Hit the plus (+) button in the 404 section of the sidebar. This creates a HTTP endpoint with the HTTP verb (POST) and path (/test) set from the request that creates the 404.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.44.54_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.44.54_AM.png)
 
-2. Hover over the white dot on the left hand side. Here, you'll see the full body of the incoming trace from when you posted to the endpoint from the REPL, including the body.
+2. Hover over the white dot on the left hand side. Here, you can see the full body of the incoming trace from when you posted to the endpoint from the REPL, including the body.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.45.57_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.45.57_AM.png)
 
-3. Let's work with the request directly and save the incoming body to a record by typing `let data = request.body` again. The autocomplete will assist with the fieldnames.
+3. Let's save the `request` body to a variable by typing `let data = request.body`. As you can see, the autocomplete knows the field names of `request` from the trace, and will complete them for you.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.47.10_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.47.10_AM.png)
 
-4. Let's put this in a datastore. Like our HttpClient library, typing "DB" in the blank will pull up all datastore functions.
+4. Let's put this in a datastore. Like we saw with the `HttpClient` library, typing "DB" in the blank will pull up all datastore functions.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.48.24_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.48.24_AM.png)
 
-In this case, we want db::set, which takes three parameters.
+In this case, we want `DB::set`, which takes three arguments.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.48.51_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.48.51_AM.png)
 
-5. Now let's make our datastore. From the sidebar or the omnibox, create a new datastore called "requests" and give it two field names.
+5. Now let's make our datastore. From the sidebar or the omnibox, create a new datastore called "Requests", with fields `data` and `time`.
 
 ![assets/gettingstarted/datastore.png](assets/gettingstarted/datastore.png)
 
-All datastores in Dark are key-value based and use keys as unique identifiers for the record. For instance, a possible set of records with keys in the above datastore would look like this:
+Dark's datastores are key-value stores; each record has a unique key that is used to store and retrieve the value. For instance, a possible set of records with keys in the above datastore would look like this:
 
 ```text
 {
@@ -50,22 +50,22 @@ All datastores in Dark are key-value based and use keys as unique identifiers fo
 
 6. Now that we have a datastore, let's finish our post endpoint.
 
-The first parameter is the record we're inserting. This will match our schema of date & time. In Dark, all fields must be included for DB::set. We'll insert our data from above (seeing the live value to the left) and the Date::now function to get a time.
+   The first argument is the record we're inserting. This needs to match the schema, and so it needs to include both `date` and `time` (you cannot insert records that are missing fields). Insert our data from above (seeing the live value to the left) and use the `Date::now` function to get the `time` field.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.57.58_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.57.58_AM.png)
 
-7. We'll need a unique key for each object. In this case, by typing db, we get the built in db::GenerateKey function.
+7. We need a unique key for each record that we store. The `DB::generateKey` function generates random keys &ndash; this is useful when your record has no obvious unique identifier.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.59.24_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.59.24_AM.png)
 
-8. Lastly, we'll use the autocomplete to add our datastore, Requests.
+8. The final argument is the Datastore: `Requests`.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_11.00.04_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_11.00.04_AM.png)
 
-9. To run the DB::set operation on our existing trace, we first need to run the two functions with side effects (db::generateKey and Date::now) by hitting the play button. After hitting those two play buttons, DB::set will be green:
+9. To call the `DB::set` function, we first need to run the two functions with side effects (`DB::generateKey` and `Date::now`) by hitting the play button. After hitting those two play buttons, the `DB::set` play button will be enabled:
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_11.00.55_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_11.00.55_AM.png)
 
-10. Finally, hitting the play button for DB::set will insert the record into the datastore, and lock the schema.
+10. Finally, hitting the play button for `DB::set` inserts the record into the datastore. This locks the datastore, preventing us from changing the schema, which we see indicated by the red lock (🔒) icon.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_11.01.32_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_11.01.32_AM.png)

--- a/docs/first-repl.md
+++ b/docs/first-repl.md
@@ -30,7 +30,7 @@ This will show you all the standard library functions for HTTPClient, their sign
 
 Dark automatically creates blanks for the four arguments that `HttpClient::post` requires. We display a grey play button beside the function &ndash; it will turn green when all the arguments are complete, allowing you to run the function from within the editor.
 
-5. Let's call a new `/test` endpoint for the application we're developing. As we saw from the GET, our endpoints live at https:/<span></span>/USERNAME-gettingstarted.builtwithdark.com, so enter a string like `"https://USERNAME-gettingstarted.builtwithdark.com/test"`.
+5. Let's call a new `/test` endpoint for the application we're developing. As we saw from the GET, our endpoints live at USERNAME-gettingstarted.builtwithdark.com, so enter a string like `"https://USERNAME-gettingstarted.builtwithdark.com/test"`.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.24.08_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.24.08_AM.png)
 

--- a/docs/first-repl.md
+++ b/docs/first-repl.md
@@ -3,47 +3,55 @@ id: first-repl
 title: Your first REPL
 ---
 
-Concepts: REPLs, HttpClient Library, Play Buttons
+**Concepts:** REPLs, HttpClient library, Play buttons
 
-1. Create a new REPL from the sidebar or the omnibox. This lets you write any code that you'd like to use for development.
-2. Type "httpclient" in the REPL.
+REPLs in Dark are general-purpose coding blocks. They're typically used in the
+way you might write a bash script (reusable tools), use traditional REPLs
+(experiments and one-off commands), or admin dashboards (simple reporting).
+
+We'll run you through creating your first REPL, experimenting with the
+HTTPClient library to make API calls.
+
+1. Create a new REPL from the sidebar or the omnibox (`Ctrl-K`/`Cmd-K`).
+
+2. Type "httpclient" in the REPL (lowercase, no spaces)
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.20.25_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.20.25_AM.png)
 
 This will show you all the standard library functions for HTTPClient, their signatures, and their docstrings.
 
-3. Continue typing, until you have httpclientpost. Dark will autocomplete, so you do not need to get the exact text (see I did not capitalize or type ::):
+3. Continue typing, until you have "httpclientpost". Dark autocompletes on substrings so getting the exact text isn't important:
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.21.21_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.21.21_AM.png)
 
-4. Hit enter to add the expression.
+4. Hit enter to add the function into the handler.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.22.01_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.22.01_AM.png)
 
-The expression automatically creates blanks for the four parameters that HttpClient::post takes, and when those are complete has a play button (grey triangle) that will allow you to run the expression from within the editor.
+Dark automatically creates blanks for the four arguments that `HttpClient::post` requires. We display a grey play button beside the function &ndash; it will turn green when all the arguments are complete, allowing you to run the function from within the editor.
 
-5. Let's call a new `/test` endpoint for the application we're developing. As we saw from the GET, our endpoints live at USERNAME-gettingstarted.builtwithdark.com, so enter a string like `"https://USERNAME-gettingstarted.builtwithdark.com/test"`.
+5. Let's call a new `/test` endpoint for the application we're developing. As we saw from the GET, our endpoints live at https:/<span></span>/USERNAME-gettingstarted.builtwithdark.com, so enter a string like `"https://USERNAME-gettingstarted.builtwithdark.com/test"`.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_9.24.08_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_9.24.08_AM.png)
 
-6. Now we need to add the body, query, and headers. Add `{test:"test1"}` for the body, empty object for the query, and json content type for the header. The editor will support you:
+6. Next let's add the arguments. The structured editor simplifies creation the arguments we want:
 
-- For the body type {, hit enter, then add the key and the value.
-- For the query type {
-- For the header type json and autocomplete will give you the formatted header.
+- For the body, we want to pass `{test:"test1"}`: type `{`, hit enter, then add the key and the value.
+- For the query, we want an empty dictionary. Type `{`.
+- For the header, we want the JSON content-type: type "json" and the autocomplete will offer you a function to use.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.41.50_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.41.50_AM.png)
 
-7. Once we've filled in all the parameters, the play button next to the method (triangle) turns green, which means we can execute this code from within the editor.
+7. Once we've filled in all the arguments, the play button (▶️) next to the function turns green, which means we can execute this code from within the editor.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.42.45_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.42.45_AM.png)
 
-8. Hitting play we receive a 404 response. This is because there's no /test endpoint on our canvas (yet!)
+8. Hitting play we receive a 404 response. This is because there's no `/test` endpoint on our canvas (yet!)
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.43.39_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.43.39_AM.png)
 
-9. Since we called it, the endpoint also appears in the 404 section on the sidebar.
+9. 404s in Dark appear in the 404 section of the sidebar. We'll discuss that more later.
 
 ![assets/gettingstarted/Screen_Shot_2020-02-11_at_10.44.10_AM.png](assets/gettingstarted/Screen_Shot_2020-02-11_at_10.44.10_AM.png)
 
-Congratulations! You've used your first REPL and written an HTTPClient expression.
+Congratulations! You've built your first REPL and called your first function in Dark.

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,8 @@
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version",
     "lint": "markdownlint --config markdownlint.json ../docs/*.md",
-    "format": "prettier --write ../docs/*.md"
+    "format": "prettier --write ../docs/*.md",
+    "check-format": "prettier --check ../docs/*.md"
   },
   "devDependencies": {
     "docusaurus": "^1.14.3",


### PR DESCRIPTION
Making my way through the docs.

This also adds `yarn check-format` and runs it in CI.

Major changes:
- use icon inline when possible
- separate intro from first step
- use "arguments" properly instead of "parameters"
- remove use of "will" (future tense) in many cases, keeping consistency in the tenses
