### PR TITLE
Improve custom-domains doc

### DIFF
--- a/docs/custom-domains.md
+++ b/docs/custom-domains.md
@@ -4,10 +4,10 @@ title: Set a Custom Domain
 sidebar_label: Set a Custom Domain
 ---
 
-If you'd like to use a custom domain instead of `<canvas>.builtwithdark.com`, you can!
+If you'd like to use a custom domain instead of `<your_canvas>.builtwithdark.com`, you can!
 
 - We'll manage SSL for you - no need to buy your own cert.
-- You need to set up a CNAME from your desired domain to `canvas.builtwithdark.com`.
+- You need to set up a CNAME from your desired domain to `<your_canvas>.builtwithdark.com`.
 
   - Note: this cannot be an apex (`foo.com`); using `www.foo.com` is the usual
     way, though you could use `app` or `api` or another subdomain instead of


### PR DESCRIPTION
B/c a user did this:
> I've followed the steps at https://darklang.github.io/docs/custom-domains, and have api.luos.app pointing at CNAME canvas.builtwithdark.com.

Instead of using their own canvas' name.