### PR TITLE
Add link to slide template

### DIFF
--- a/docs/sharing-your-dark-projects.md
+++ b/docs/sharing-your-dark-projects.md
@@ -6,17 +6,9 @@ sidebar_label: Sharing Your Dark Projects
 
 Thanks for being part of our private beta! We're excited for you to share your Dark projects. The most important thing to us is getting your feedback. We appreciate hearing about bugs, requests, etc, in the Slack.
 
-That said, we're happy for you to share publicly. The best way to share code for now is often via screenshot (ex: [https://twitter.com/janiczek/status/1220519157135003649](https://twitter.com/janiczek/status/1220519157135003649)) although we're working on better ways to copy/paste out.
-
-Here's a couple examples of users sharing about Dark:
-
-- [Kevin Hoffman's blog](https://medium.com/@KevinHoffman/shedding-some-light-on-dark-9086b45988ed) about IoT sensors
-- Tair's [snipy tool for Slack](https://snipy.io/).
-- You're also welcome to tweet! If you tag us [@darklang](https://twitter.com/darklang) we'll try to RT, too.
-
 ## Made with Dark badge
 
-Did your project launch? Give it a "Made with Dark" badge.
+If your project has launched, you can give it a "Made with Dark" badge.
 
 <div class="badges lightBackground">
   <div class="badge">
@@ -102,11 +94,21 @@ Did your project launch? Give it a "Made with Dark" badge.
   </div>
 </div>
 
-## Logo
+## Other Logos
 
-If you write something about Dark, feel free to let your readers know that they can get into the Dark beta faster if they mention your name/username in their [application to the Dark beta.](https://darklang.com/beta)
-
-If you'd like a logo to use in your website, blog, here is one:
-
-![assets/branding/logo@1x.png](assets/branding/logo@1x.png)
 Files: [svg](assets/branding/logo.svg) | [png](assets/branding/logo@1x.png) | [png 2x](assets/branding/logo@2x.png) | [png 3x](assets/branding/logo@3x.png)
+
+## Writing about Dark
+
+You can share your experience with Dark publicly. Here's a couple examples of users sharing about Dark:
+
+- [Kevin Hoffman's blog](https://medium.com/@KevinHoffman/shedding-some-light-on-dark-9086b45988ed) about IoT sensors
+- Tair's [snipy tool for Slack](https://snipy.io/).
+- The best way to share code for now is often via screenshot (ex: [Ellie's Project](https://twitter.com/janiczek/status/1220519157135003649)).
+- If you tag us on Twitter, [@darklang](https://twitter.com/darklang) we'll try to RT.
+
+Feel free to let your readers know that they can ask you for an invite, or if you'd like a multi-use invite link, you can request one in the community Slack.
+
+## Giving talks about Dark
+
+We've also seen users give talks about Dark at meetups and at work. If you'd like to do so, we've shared slide templates and logos to help make that easier. [slide template](https://drive.google.com/drive/u/1/folders/15GkcOu8jfJkgmk3aY7HxJjWdKgtDBY7C).


### PR DESCRIPTION
Slight changes to sharing Dark page, adds link to slide template per requests in community Slack.