### PR TITLE
Adds simple page to refer to the desktop client

### DIFF
--- a/docs/desktop-client.md
+++ b/docs/desktop-client.md
@@ -1,0 +1,11 @@
+---
+id: desktop-client
+title: Desktop Client
+sidebar_label: Desktop Client
+---
+
+## Desktop Client
+
+If you prefer to run Dark as an application, we offer a desktop client version. This prevents interference with browser extensions.
+
+[Install](https://darklang.com/desktop-client)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -39,7 +39,8 @@
       "known-issues",
       "sharing-dark",
       "changelog",
-      "faqs"
+      "faqs",
+      "desktop-client"
     ]
   },
   "Slack": {


### PR DESCRIPTION
Have received several recent emails that this was an appropriate response for. Given user success with desktop client, think we should make it known that it's available.