### PR TITLE
Fix invalid links when served with trailing slash

### DIFF
--- a/docs/contributing/general-concepts.md
+++ b/docs/contributing/general-concepts.md
@@ -138,7 +138,7 @@ type pattern =
 ```
 
 These definitions are in ReScript (we have a
-[guide to ReScript for Dark developers](ocaml-for-dark-developers)). Briefly,
+[guide to ReScript for Dark developers](ocaml-for-dark-developers.md)). Briefly,
 this means that an `expr` is an integer (which is made up of an id and a string)
 or a bool (made up of an id and a string), or a `match` (which is an id, an
 expression to match on, and a list of patterns and expressions), etc

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -3,12 +3,12 @@ title: Getting started
 ---
 
 _Note that you can also
-[contribute without writing OCaml code](./if-you-dont-know-ocaml)!_
+[contribute without writing OCaml code](if-you-dont-know-ocaml.md)!_
 
 This guide will get you making your first PR to the Dark repo. It helps you set
 up the repo, write your first test, and make your first pull request. After
 that, it will guide you on how to work on bigger things, especially the current
-big project to [port the backend to F#](porting-the-dark-backend).
+big project to [port the backend to F#](porting-the-dark-backend.md).
 
 If you'd like help contributing, you can
 [book a pairing session with Paul Biggar to help](https://calendly.com/paul-biggar/dark-contributor-pairing-session).

--- a/docs/contributing/if-you-dont-know-ocaml.md
+++ b/docs/contributing/if-you-dont-know-ocaml.md
@@ -71,7 +71,7 @@ Dark. Fortunately, they are very similar to Dark.
 
 There are a number of resources to help as well:
 
-- [A guided walkthrough of making your first PR](/contributing/adding-your-first-test)
+- [A guided walkthrough of making your first PR](adding-your-first-test.md)
 - [good first bugs](https://github.com/darklang/dark/issues?q=is%3Aopen+is%3Aissue+label%3Agood-first-bug)
   assume you don't know anything about F# or ReScript
 

--- a/docs/contributing/making-your-first-pull-request.md
+++ b/docs/contributing/making-your-first-pull-request.md
@@ -46,7 +46,7 @@ request:
 > any tests so I added one."
 
 While this doesn't follow our
-[Pull Request guidelines](/contributing/making-a-pull-request#writing-a-successful-pull-request-message),
+[Pull Request guidelines](making-a-pull-request.md#writing-a-successful-pull-request-message),
 it's fine for a first contribution (and you can ignore the PR template too for
 now).
 

--- a/docs/contributing/next-contribution.md
+++ b/docs/contributing/next-contribution.md
@@ -2,19 +2,19 @@
 title: Your next contribution
 ---
 
-We have everyone start with [a first PR](getting-started), which makes a small
+We have everyone start with [a first PR](getting-started.md), which makes a small
 but valuable contribution. Now that you've got it done, you can build something
 (a little bit) bigger.
 
 ## Porting backend to F#
 
 One of the most valuable projects right now is porting OCaml code to F# in the
-backend. See [Porting the Dark backend](porting-the-dark-backend).
+backend. See [Porting the Dark backend](porting-the-dark-backend.md).
 
 ## Getting started
 
 Below you'll find resources to help you figure out what to work on. After that,
-head over to [Working in the Dark repo](ocaml-for-dark-developers) to learn how
+head over to [Working in the Dark repo](ocaml-for-dark-developers.md) to learn how
 to contribute bigger things, like the basics of F#/ReScript, the layout of the
 repo, technical guides to different parts of the codebase and product, and
 product and vision docs about where Dark is going.


### PR DESCRIPTION
The Issue:

Visit this URL directly: https://docs.darklang.com/contributing/getting-started
301 Redirects to (note trailing slash): https://docs.darklang.com/contributing/getting-started/ 

The internal links on this page are now invalid, for example - https://docs.darklang.com/contributing/getting-started/if-you-dont-know-ocaml

`if-you-dont-know-ocaml` is getting appended to `https://docs.darklang.com/contributing/getting-started/` 

If you navigate to this page through JS, avoiding the 301 redirect and actually arriving at https://docs.darklang.com/contributing/getting-started (no trailing slash) then `if-you-dont-know-ocaml` is getting appended to `https://docs.darklang.com/contributing/` and the link is correct. 

I encountered this by navigating to the contributor docs from the dark README link, https://darklang.github.io/docs/contributing/getting-started, which ultimately leaves you on the trailing slash page with invalid links.

See some discussion here - https://github.com/facebook/docusaurus/issues/3372 and https://github.com/facebook/docusaurus/issues/5250. 

The simplest fix seems to be linking directly to documents instead of using URL paths, as I have applied here for just the contributing pages.

There is a `trailingSlash` added from version `2.0.0-beta.df8a900f9` onwards, however upgrading to this seemed to have numerous breaking changes.
