### PR TITLE
Add analysis to changelog

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 sidebar_label: Changelog
 ---
 
-## 2021-January 2022
+## 2021-2022
 
 We have been doing a major rewrite of our backend, moving from OCaml to F#. This
 solves significant operational issues and opens Dark to a lot of improvements
@@ -27,6 +27,16 @@ some other ways to avoid the problem.
 
 _The list below is organized by date discovered, to allow you know when new
 things have been added to the list since you last checked._
+
+## Discovered before Feb 28, 2022:
+
+We have changed the execution engine in the Darklang editor (used when editing on
+darklang.com or in the Desktop Client). If you experience any issues, you can revert
+to the old execution enginer using the `use-ocaml-analysis=true` query param, (eg
+`https://darklang.com/a/CANVASNAME?use-ocaml-analysis=true`). In the Darklang Desktop
+application, you can open the JS console and run `window.DarkAnalysis.useOcaml =
+true`). We are aware of some performance issues, and will be working on these in the
+future.
 
 ## Discovered before Jan 10, 2022:
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -30,13 +30,13 @@ things have been added to the list since you last checked._
 
 ## Discovered before Feb 28, 2022:
 
-We have changed the execution engine in the Darklang editor (used when editing on
-darklang.com or in the Desktop Client). If you experience any issues, you can revert
-to the old execution enginer using the `use-ocaml-analysis=true` query param, (eg
-`https://darklang.com/a/CANVASNAME?use-ocaml-analysis=true`). In the Darklang Desktop
-application, you can open the JS console and run `window.DarkAnalysis.useOcaml =
-true`). We are aware of some performance issues, and will be working on these in the
-future.
+We have changed the execution engine in the Darklang editor (used when editing
+on darklang.com or in the Desktop Client). If you experience any issues, you can
+revert to the old execution enginer using the `use-ocaml-analysis=true` query
+param, (eg `https://darklang.com/a/CANVASNAME?use-ocaml-analysis=true`). In the
+Darklang Desktop application, you can open the JS console and run
+`window.DarkAnalysis.useOcaml = true`). We are aware of some performance issues,
+and will be working on these in the future.
 
 ## Discovered before Jan 10, 2022:
 


### PR DESCRIPTION
Rework of #225. The goal here was to move it within the larger "rewrite" notes, and to reduce its size to just the smallest set of facts a developer may need to know.