### PR TITLE
Fix images not being shown in a correct dimension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 .DS_Store
 
 npm-debug.log*
+
+# ide and editors
+.idea
+.vscode

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -50,6 +50,10 @@ a {
   color: #6d74c5;
 }
 
+img {
+  height: auto;
+}
+
 .badges {
   margin: 2em 0;
   display: flex;


### PR DESCRIPTION
The images shown in the docs are a bit out of dimension due to a `max-width: 100%`

![image](https://user-images.githubusercontent.com/4103756/176157423-4dd20f3b-9fb8-4ecd-a87d-8af2cf303336.png)

After adding `height:auto` it seems to be fixed

![image](https://user-images.githubusercontent.com/4103756/176157746-cd438090-db15-4d29-bb19-a0afe899e220.png)
