### PR TITLE
add contextualSearch option to algolia field, set to false

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -155,6 +155,7 @@ module.exports = {
       appId: "QFOZBC0VVL",
       apiKey: "715121cc838a8c3c4ea54324456bd5f9",
       indexName: "darklang",
+      contextualSearch: false,
     },
   },
   presets: [


### PR DESCRIPTION
Added contextualSearch option set to "false". W/O option specified, contextualSearch defaults to "true", which searches w/ facetFilters.