### PR TITLE
Remove duplicate Tuples section in Lang Details

### DIFF
--- a/docs/reference/languagedetails.md
+++ b/docs/reference/languagedetails.md
@@ -467,15 +467,6 @@ execute.
 
 ## Planned language features
 
-### Tuples
-
-Dark intends to support tuples: lists of defined length supporting heterogeneous
-types.
-
-```elm
-x = (1, "string", { name: "Sam" })
-```
-
 ### Sets
 
 We intend for Dark to support Sets: unordered collections of a single type.


### PR DESCRIPTION
No changelog

I noticed that we had a duplicate 'Tuples' section in the Language Details docs. This removes the outdated section.