### PR TITLE
Chrisbrandt/language reference - Turn off draft for language-reference.md

### DIFF
--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -28,7 +28,7 @@ The documentation is split into:
 - [how-to guides](/next/category/how-to-guides) for using Darklang features
 - [step-by-step guides](/next/category/step-by-step-guides) for creating
   applications in Darklang
-- [language and platform reference](./category/reference)
+- [language and platform reference](/next/category/reference)
 - [background, discussions and explanations](/next/category/discussion)
 
 New folks should start at the

--- a/docs/reference/language-reference.md
+++ b/docs/reference/language-reference.md
@@ -6,7 +6,7 @@ keywords:
   - types
   - control
   - control-flow
-draft: true
+draft: false
 ---
 
 No content yet!


### PR DESCRIPTION
Changelog:

```
Area of change
- normalize path to Reference category
- turn off draft in language-reference meta-data so that the category shows up
```


