### PR TITLE
change :: to . operator. Completed Bool operators

### DIFF
--- a/docs/reference/language-reference/built-in-types/bool.md
+++ b/docs/reference/language-reference/built-in-types/bool.md
@@ -38,7 +38,7 @@ Bool.and(Bool, Bool) -> Bool
 ```darklang
 let x = true
 let y = false
-Bool::and x y
+Bool.and x y
 ```
 
 This trace returns: false
@@ -46,7 +46,7 @@ This trace returns: false
 ```darklang
 let x = [false,false,true,true]
 let y = [false,true,false,true]
-List::map2 x y \a, b -> Bool::and a b
+List.map2 x y \a, b -> Bool.and a b
 ```
 
 This trace returns:
@@ -56,7 +56,7 @@ This trace returns:
 
 #### Shorthand: &&
 
-A double ampersand provides an inline shortcut for Bool:and(). Note that this operator is lazy (the right hand term is only evaluated if the left hand term does not determine the result)
+A double ampersand provides an inline shortcut for Bool.and(). Note that this operator is lazy (the right hand term is only evaluated if the left hand term does not determine the result)
 
 #### Example
 
@@ -67,3 +67,135 @@ x && y
 ```
 
 This trace returns: false
+
+----
+
+### OR
+
+The logical OR of two boolean values. Returns a bool.
+
+#### Truth Table
+
+| X | Y | OR(X,Y) |
+|---|---|---|
+| false | false | false |
+| false | true | true |
+| true | false | true |
+| true | true | true |
+
+#### Definition
+
+Bool.or(Bool, Bool) -> Bool
+
+#### Examples
+
+```darklang
+let x = true
+let y = false
+Bool.or x y
+```
+
+This trace returns: true
+
+```darklang
+let x = [false,false,true,true]
+let y = [false,true,false,true]
+List.map2 x y \a, b -> Bool.or a b
+```
+
+This trace returns:
+[
+  false, true, true, true
+]
+
+#### Shorthand: ||
+
+A double vertical pipe provides an inline shortcut for Bool.or(). Note that this operator is lazy (the right hand term is only evaluated if the left hand term does not determine the result)
+
+#### Example
+
+```darklang
+let x = true
+let y = false
+x || y
+```
+
+This trace returns: true
+
+----
+
+### NOT
+
+The logical NOT of a boolean value. Returns a bool.
+
+#### Truth Table
+
+| X | NOT(X) |
+|---|---|
+| false | true |
+| true | false |
+
+#### Definition
+
+Bool.not(Bool, Bool) -> Bool
+
+#### Examples
+
+```darklang
+let x = true
+Bool.not x
+```
+
+This trace returns: false
+
+```darklang
+let x = [false,true]
+List.map x \a -> Bool.not a
+```
+
+This trace returns:
+[
+  true, false
+]
+
+----
+
+### XOR
+
+The logical exclusive OR of two boolean values. Returns a bool.
+
+#### Truth Table
+
+| X | Y | XOR(X,Y) |
+|---|---|---|
+| false | false | false |
+| false | true | true |
+| true | false | true |
+| true | true | false |
+
+#### Definition
+
+Bool.xor(Bool, Bool) -> Bool
+
+#### Examples
+
+```darklang
+let x = true
+let y = false
+Bool.xor x y
+```
+
+This trace returns: true
+
+```darklang
+let x = [false,false,true,true]
+let y = [false,true,false,true]
+List.map2 x y \a, b -> Bool.xor a b
+```
+
+This trace returns:
+[
+  false, true, true, false
+]
+
+----

--- a/docs/reference/language-reference/built-in-types/int.md
+++ b/docs/reference/language-reference/built-in-types/int.md
@@ -41,15 +41,15 @@ The mathmatical absolute value of the integer.
 
 #### Definition
 
-Int::absoluteValue(Int: a) -> Int
+Int.absoluteValue(Int: a) -> Int
 
 #### Example
 
 ```darklang
 let x = -1
 let y = 1
-let X = Int::absoluteValue x
-let Y = Int::absoluteValue y
+let X = Int.absoluteValue x
+let Y = Int.absoluteValue y
 [X,Y]
 ```
 
@@ -61,14 +61,14 @@ The sum of two integers.
 
 #### Definition
 
-Int::add(Int: a, Int: b) -> Int
+Int.add(Int: a, Int: b) -> Int
 
 #### Example
 
 ```darklang
 let x = -1
 let y = 1
-let z = Int::add x y
+let z = Int.add x y
 z
 ```
 


### PR DESCRIPTION
Changelog:

```
Area of change
- Int and Bool pages
```

Changed namespace - function number separator from :: to . (ie, Bool.and)
Added Bool.or, Bool.not, Bool.xor to complete the Bool page.